### PR TITLE
Fix headers parsing for multiple CSV files

### DIFF
--- a/Reader/CsvReader.php
+++ b/Reader/CsvReader.php
@@ -65,6 +65,7 @@ class CsvReader implements ReaderInterface
         );
 
         // init headers
+        $this->defaultContext[self::HEADERS_KEY] = [];
         if (!$this->defaultContext[self::NO_HEADERS_KEY]) {
             $this->rewind();
             $this->defaultContext[self::HEADERS_KEY] = $this->file->current();


### PR DESCRIPTION
When dealing with multiple CSV files with a header line and after parsing the first file, the lib would fail to read the header of the second file because the headers of the first file were not cleaned.